### PR TITLE
Add preprocessor option to preserve line layout

### DIFF
--- a/mojoshader_internal.h
+++ b/mojoshader_internal.h
@@ -241,6 +241,14 @@ typedef Uint64 uint64;
 #define MATCH_MICROSOFT_PREPROCESSOR 1
 #endif
 
+// When enabled the preprocessor output will contain exactly the same number
+// of newline characters as the input. Any carriage returns or trailing
+// whitespace will be removed and lines from skipped conditional branches will
+// be represented by empty lines in the output.
+#ifndef PRESERVE_PP_OUTPUT_LINES
+#define PRESERVE_PP_OUTPUT_LINES 0
+#endif
+
 // Other stuff you can disable...
 
 #ifdef MOJOSHADER_EFFECT_SUPPORT


### PR DESCRIPTION
## Summary
- add `PRESERVE_PP_OUTPUT_LINES` compile-time flag
- keep newline tokens while skipping branches
- trim trailing whitespace and preserve exact line count when the flag is enabled

## Testing
- `cmake ..`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_683fa3ae583c832083650bc651eaf412